### PR TITLE
Check if the body len is 0 to return an empty body since http.Nobody …

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -18,9 +18,7 @@ import (
 
 const Namespace = "github.com/devopsfaith/krakend-jsonschema"
 
-var (
-	ErrEmptyBody = &malformedError{err: errors.New("could not validate an empty body")}
-)
+var ErrEmptyBody = &malformedError{err: errors.New("could not validate an empty body")}
 
 // ProxyFactory creates an proxy factory over the injected one adding a JSON Schema
 // validator middleware to the pipe when required

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -157,7 +157,7 @@ func TestProxyFactory_validationOK(t *testing.T) {
 }
 
 func TestProxyFactory_invalidJSON(t *testing.T) {
-	errExpected := "could not validate a malformed body"
+	errExpected := "invalid character '\\n' in string literal"
 	statusExpected := http.StatusBadRequest
 	pf := ProxyFactory(logging.NoOp, proxy.FactoryFunc(func(cfg *config.EndpointConfig) (proxy.Proxy, error) {
 		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
@@ -235,7 +235,7 @@ func TestProxyFactory_emptyBody(t *testing.T) {
 			t.Errorf("unexpected error %s", err.Error())
 			return
 		}
-		_, err = p(context.Background(), &proxy.Request{Body: nil})
+		_, err = p(context.Background(), &proxy.Request{Body: http.NoBody})
 		if err == nil {
 			t.Error("expecting error")
 			return


### PR DESCRIPTION
…is used in lura. Add the actual error to the malformed body error.

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>